### PR TITLE
Added seed for reproducing plots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 NetworkLayout = "46757867-2c16-5918-afeb-47bfcb05e46a"
 Plasmo = "d3f7391f-f14a-50cc-bbe4-76a32d1bad3c"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/src/PlasmoPlots.jl
+++ b/src/PlasmoPlots.jl
@@ -6,6 +6,7 @@ using Plots
 using NetworkLayout
 using GeometryBasics: Point2f0, Point
 using Colors
+using Random
 using Graphs
 
 export layout_plot, matrix_plot

--- a/src/layout_plot.jl
+++ b/src/layout_plot.jl
@@ -10,6 +10,8 @@
         markersize=30,
         labelsize=20, 
         markercolor=:grey,
+        use_seed=true,
+        seed=1,
         layout_options = Dict(
             :tol => 0.01,
             :C => 2,
@@ -40,6 +42,8 @@ Plot a graph layout of the optigraph `graph`. The following keyword arguments ca
 * `markersize = 30`: the markersize which determines the size of each node in `graph`.
 * `labelsize = 20`: the size for each node label.  Only active if `node_labels = true`.
 * `markercolor = :grey`: the color for each node.
+* `use_seed = true`: whether to use a random seed for reproducibility in generating initial positions of nodes
+* `seed = 1`: value of the random seed to use if `use_seed=true`
 
 * `layout_options = Dict(:tol => 0.01,:C => 2, :K => 4, :iterations => 2)`: dictionary with options for the layout algorithm.
     * `tol`: permitted distance between a current and calculated co-ordinate.
@@ -66,6 +70,8 @@ function layout_plot(
     markersize=30,
     labelsize=20,
     markercolor=:grey,
+    use_seed=true,
+    seed=1,
     layout_options=Dict(:tol => 0.01, :C => 2, :K => 4, :iterations => 2),
     plt_options=Dict(
         :legend => false,
@@ -106,8 +112,9 @@ function layout_plot(
         markercolor = markercolor
     end
 
-    #hypergraph,hyper_map = hyper_graph(graph)
-    # clique_graph,clique_map = clique_expansion(hypergraph)
+    if use_seed
+        Random.seed!(seed)
+    end
 
     clique_proj = clique_projection(graph)
     simple_graph = clique_proj.projected_graph
@@ -161,6 +168,8 @@ end
         markersize=30,
         labelsize=20, 
         markercolor=:grey,
+        use_seed=true,
+        seed=1,
         layout_options = Dict(
             :tol => 0.01,
             :C => 2,
@@ -193,6 +202,8 @@ function layout_plot(
     markersize=30,
     labelsize=20,
     markercolor=:grey,
+    use_seed=true,
+    seed=1,
     layout_options=Dict(:tol => 0.01, :C => 2, :K => 4, :iterations => 2),
     plt_options=Dict(
         :legend => false,
@@ -248,6 +259,10 @@ function layout_plot(
     #LAYOUT
     clique_proj = clique_projection(graph)
     simple_graph = clique_proj.projected_graph
+
+    if use_seed
+        Random.seed!(seed)
+    end
 
     startpositions = Array{Point{2,Float32},1}()
     for i in 1:Graphs.nv(simple_graph)


### PR DESCRIPTION
There have been times when I have used PlasmoPlots.jl and wanted to be able to reproduce a plot that I created. However, because each call to `layout_plot` generates new positions for the nodes, it is not possible (or at least difficult) to reproduce a plot you had before. I have added to `layout_plot` a `use_seed` argument and a `seed` argument that allows the user to set a random seed before generating the initial node positions. This also meant adding `Random.jl` as a dependency.